### PR TITLE
Additions to bootstrap.less

### DIFF
--- a/bootstrap.less
+++ b/bootstrap.less
@@ -46,7 +46,7 @@
   	
 	// CSS3 columns.
 	
-	@mixin columns(@count, @gap: 1.5em){
+	.columns(@count, @gap: 1.5em){
 		-webkit-column-count: @count;
 		-webkit-column-gap: @gap;
 		-moz-column-count: @count; 
@@ -127,4 +127,14 @@
     background-repeat: no-repeat;
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), color-stop(@colorStop, @midColor), to(@endColor));
     background-image: -moz-linear-gradient(@startColor, color-stop(@midColor, @colorStop), @endColor);
+  }
+
+
+
+  // For links or buttons with background-image applied, and you want it to change on hover:
+
+  .hover(@dir: bottom){
+	&:hover{
+		background-position-y: @dir;	
+	}
   }

--- a/bootstrap.less
+++ b/bootstrap.less
@@ -58,6 +58,30 @@
 			position: static;		// Boy, it took me long time to figure this out.
 		}
 	}	
+	
+
+	// Button style
+	// Usage: include the mixin and define base color. I highly recommend you to customize these styles.
+
+	.button(@basecolor: #eee){
+			.rounded(3px);
+			-webkit-font-smoothing: antialiased;
+			display: inline-block;
+			.gradient(@basecolor, darken(@basecolor, 10%));
+			.sans-serif(bold);
+			text-align: center;
+			text-decoration: none;
+			padding: 0.3em 0.5em;
+
+		&:hover{
+
+		}
+
+		&:active{
+			.transition(none);
+			top: auto; outline: none !important;
+		}
+	}
 
 
   // Border Radius
@@ -122,6 +146,7 @@
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), to(@endColor));
     background-image: -moz-linear-gradient(@startColor, @endColor);
   }
+
   .three-color-gradient(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 0.5, @endColor: #c3325f) {
     background-color: @endColor;
     background-repeat: no-repeat;

--- a/bootstrap.less
+++ b/bootstrap.less
@@ -26,6 +26,22 @@
 /*--------------------------------------------------
   Mixins
 	-------------------------------------------------- */
+	
+  // Clearfix for use in Less files
+
+	.clearfix{
+		&:after{
+			visibility: hidden;
+	     	display: block;
+		    font-size: 0;
+	     	content: " ";
+	     	clear: both;
+	     	height: 0;	
+		}
+		& {display: inline-block;}
+		* html & {height: 1%;}
+		& {display: block;}
+	}
 
   // Border Radius
   .rounded(@radius: 5px) {

--- a/bootstrap.less
+++ b/bootstrap.less
@@ -27,7 +27,7 @@
   Mixins
 	-------------------------------------------------- */
 	
-  // Clearfix for use in Less files
+    // Clearfix for use in Less files
 
 	.clearfix{
 		&:after{
@@ -42,6 +42,23 @@
 		* html & {height: 1%;}
 		& {display: block;}
 	}
+	
+  	
+	// CSS3 columns.
+	
+	@mixin columns(@count, @gap: 1.5em){
+		-webkit-column-count: @count;
+		-webkit-column-gap: @gap;
+		-moz-column-count: @count; 
+		-moz-column-gap: @gap;
+		column-count: @count; 
+		column-gap: @gap;
+
+		& > * {
+			position: static;		// Boy, it took me long time to figure this out.
+		}
+	}	
+
 
   // Border Radius
   .rounded(@radius: 5px) {

--- a/index.html
+++ b/index.html
@@ -24,8 +24,12 @@
     
     <header>
       <p><a href="http://twitter.com/share" class="twitter-share-button" data-url="http://www.markdotto.com/2011/03/21/introducing-bootstrap/" data-count="horizontal" data-via="mdo">Tweet</a><script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script></p>
+	
+	<hgroup>
       <h1>Bootstrap.less</h1>
       <h2>Bootstrap is a super awesome pack of mixins and variables to be used in conjunction with <a href="http://lesscss.org" target="_blank">LESS</a>, a CSS preprocessor for faster and easier web development.</h2>
+	</hgroup>
+	
     </header>
     
     <section>


### PR DESCRIPTION
Added some handy mixins from my personal library:
- **Clearfix.** For easy clearing of floats directly from the Less code. No need for .clearfix classes in HTML.
- **Columns.** CSS3 Columns. Pretty straight-forward.
- **Hover.** For use with simple background sprites. Include the mixin whenever there's need for the background image to shift to the bottom.
- **Button.** This is ideal for CSS preprocessors.
