### PR TITLE
Serif font stack defaults to sans-serif font + mozilla gradients dont use color-stop()

### DIFF
--- a/bootstrap.less
+++ b/bootstrap.less
@@ -92,7 +92,7 @@
     line-height: @lineHeight;
   }
   .serif(@weight: normal, @size: 14px, @lineHeight: 20px) {
-    font-family: "Georgia", Times New Roman, Times, sans-serif;
+    font-family: "Georgia", Times New Roman, Times, serif;
     font-size: @size;
     font-weight: @weight;
     line-height: @lineHeight;

--- a/bootstrap.less
+++ b/bootstrap.less
@@ -226,7 +226,7 @@
     background-repeat: no-repeat;
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), color-stop(@colorStop, @midColor), to(@endColor));
     background-image: -webkit-linear-gradient(@startColor, color-stop(@colorStop, @midColor), @endColor);
-    background-image: -moz-linear-gradient(@startColor, color-stop(@midColor, @colorStop), @endColor);
+    background-image: -moz-linear-gradient(@startColor, @midColor @colorStop*100%, @endColor);
   }
 }
 


### PR DESCRIPTION
63185e0: #font > .serif() will default to a sans-serif font.

600bc51: Mozilla gradients simply use color [ percentage | length ] instead of a color-stop() function

https://developer.mozilla.org/en/CSS/-moz-linear-gradient
