### PR TITLE
Mixin definitions shouldn't leave styles behind

### DIFF
--- a/bootstrap.less
+++ b/bootstrap.less
@@ -42,7 +42,7 @@
 -------------------------------------------------- */
 
 // Clearfix for clearing floats like a boss
-.clearfix {
+.clearfix () {
   zoom: 1;
 	&:after {
     display: block;
@@ -54,7 +54,7 @@
 }
 
 // Center-align a block level element
-.center-block { 
+.center-block () {
 	display: block;
   margin: 0 auto;
 }
@@ -106,7 +106,7 @@
 }
 
 // Grid System
-.container {
+.container () {
   width: @siteWidth;
   margin: 0 auto;
   .clearfix();
@@ -242,7 +242,7 @@
 // CSS3 Flexible Box Module
 #flexbox {
   // #flexbox > .display-box; must be used along with other flexbox mixins
-  .display-box { 
+  .display-box () {
     display: -moz-box;
     display: -webkit-box;
     display: box;
@@ -291,10 +291,10 @@
   }
 }
 
-// Based on Eric Meyers' reset 2.0 - http://meyerweb.com/eric/tools/css/reset/index.html 
+// Based on Eric Meyers' reset 2.0 - http://meyerweb.com/eric/tools/css/reset/index.html
 // & the Compass Reset utility - http://compass-style.org/reference/compass/reset/utilities/
 #reset {
-  .global-reset {
+  .global-reset () {
     html, body, div, span, applet, object, iframe,
     h1, h2, h3, h4, h5, h6, p, blockquote, pre,
     a, abbr, acronym, address, big, cite, code,
@@ -304,73 +304,73 @@
     dl, dt, dd, ol, ul, li,
     fieldset, form, label, legend,
     table, caption, tbody, tfoot, thead, tr, th, td,
-    article, aside, canvas, details, embed, 
-    figure, figcaption, footer, header, hgroup, 
+    article, aside, canvas, details, embed,
+    figure, figcaption, footer, header, hgroup,
     menu, nav, output, ruby, section, summary,
     time, mark, audio, video {
       #reset > .reset-box-model;
-      #reset > .reset-font; 
+      #reset > .reset-font;
     }
     body {
-      #reset > .reset-body; 
+      #reset > .reset-body;
     }
     ol, ul {
-      #reset > .reset-list-style; 
+      #reset > .reset-list-style;
     }
     table {
-      #reset > .reset-table; 
+      #reset > .reset-table;
     }
     caption, th, td {
-      #reset > .reset-table-cell; 
+      #reset > .reset-table-cell;
     }
     q, blockquote {
-      #reset > .reset-quotation; 
+      #reset > .reset-quotation;
     }
     a img {
-      #reset > .reset-image-anchor-border; 
+      #reset > .reset-image-anchor-border;
     }
     #reset > .reset-html5;
   }
-  .reset-box-model {
+  .reset-box-model () {
     margin: 0;
     padding: 0;
-    border: 0; 
+    border: 0;
   }
-  .reset-font {
+  .reset-font () {
     font-size: 100%;
     font: inherit;
     vertical-align: baseline;
   }
-  .reset-focus {
+  .reset-focus () {
     outline: 0;
   }
-  .reset-body {
+  .reset-body () {
     line-height: 1;
   }
-  .reset-list-style {
+  .reset-list-style () {
     list-style: none;
   }
-  .reset-table {
+  .reset-table () () {
     border-collapse: collapse;
     border-spacing: 0;
   }
-  .reset-table-cell {
+  .reset-table-cell () {
     text-align: left;
     font-weight: normal;
     vertical-align: middle;
   }
-  .reset-quotation {
+  .reset-quotation () {
     quotes: none;
     &:before, &:after {
-      content: ""; 
+      content: "";
       content: none;
     }
   }
-  .reset-image-anchor-border {
+  .reset-image-anchor-border () {
     border: none;
   }
   .reset-html5 {
-    article, aside, details, figcaption, figure, 
+    article, aside, details, figcaption, figure,
     footer, header, hgroup, menu, nav, section {
       display: block;
     }

--- a/bootstrap.less
+++ b/bootstrap.less
@@ -350,7 +350,7 @@
   .reset-list-style () {
     list-style: none;
   }
-  .reset-table () () {
+  .reset-table () {
     border-collapse: collapse;
     border-spacing: 0;
   }


### PR DESCRIPTION
This change just puts empty parens on mixins that don't take params. This way you don't get a bunch of styles you might not have wanted included just by importing bootstrap.less.

In my use case I've got user configurable stylesheets, several of which get dropped on a page. Each user stylesheet is wrapped in such a way by my code that gives it access to all of bootstrap's mixins. If there aren't parens on no-param mixins then every style block I generate will have the entirety of those mixins included as static styles (the worst offenders being the `#reset` namespaced mixins).

The one downside is that it does exclude some dual purpose mixins from also being regular classes. Eg, `clearfix` is no longer a class that you can put on an element in the markup. Still, I'd argue that it would be wrong to do so anyway and it would be better to use `.clearfix();` in your styles somewhere instead...

So, just throwing this over to you, see if you agree/want to pull it in.
