### PR TITLE
.center-block resets margin-top and bottom declarations

### DIFF
--- a/bootstrap.less
+++ b/bootstrap.less
@@ -55,8 +55,9 @@
 
 // Center-align a block level element
 .center-block { 
-	display: block;
-  margin: 0 auto;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 // Sizing shortcuts


### PR DESCRIPTION
.center-block should only set left and right margins, .center-block would replace a margin-top or -bottom declaration, if used after.
