### PR TITLE
Small clearfix change

### DIFF
--- a/bootstrap.less
+++ b/bootstrap.less
@@ -49,7 +49,7 @@
     visibility: hidden;
     height: 0;
     clear: both;
-    content: ".";
+    content: "\0020";
 	}
 }
 


### PR DESCRIPTION
Replace "." with "\0020" in .clearfix to avoid blank space at the bottom of the page. Reference: http://blueprintcss.lighthouseapp.com/projects/15318/tickets/5-extra-margin-padding-bottom-of-page
