### PR TITLE
Updated the clearfix mixin

### DIFF
--- a/less/preboot.less
+++ b/less/preboot.less
@@ -348,10 +348,14 @@
 // 2. The use of `table` rather than `block` is only necessary if using
 //    `:before` to contain the top-margins of child elements.
 .clearfix() {
+  *zoom: 1;
   &:before,
   &:after {
     content: " "; // 1
     display: table; // 2
+    // Fixes Opera/contenteditable bug:
+    // http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952
+    line-height: 0;
   }
   &:after {
     clear: both;


### PR DESCRIPTION
Added zoom: 1 and the fix for the Opera/contenteditable bug (http://nicolasgallagher.com/micro-clearfix-hack/#comment-36952) to the clearfix mixin.

Also matches the current clearfix used in Bootstrap.
