### PR TITLE
Fix link for Textarea resize in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ layout: default
         <li><a href="#mixins-clearfix">Clearfix</a></li>
         <li><a href="#mixins-centering">Horizontal centering</a></li>
         <li><a href="#mixins-sizing">Sizing helpers</a></li>
-        <li><a href="#mixins-resize">Textarea resize</a></li>
+        <li><a href="#mixins-resizable">Textarea resize</a></li>
         <li><a href="#mixins-truncating">Truncating text</a></li>
         <li><a href="#mixins-retina-images">Retina images</a></li>
       </ul>


### PR DESCRIPTION
Mismatched ID's for Textarea resize cause a broken link in the documentation.

Replaced Textarea resize link href with #mixins-resizable to point to the proper element within documentation.
