### PR TITLE
simplify media queries for retina-image mixin

### DIFF
--- a/less/preboot.less
+++ b/less/preboot.less
@@ -394,12 +394,8 @@
   background-image: url("@{file-1x}");
 
   @media
-  only screen and (-webkit-min-device-pixel-ratio: 2),
-  only screen and (   min--moz-device-pixel-ratio: 2),
-  only screen and (     -o-min-device-pixel-ratio: 2/1),
-  only screen and (        min-device-pixel-ratio: 2),
-  only screen and (                min-resolution: 192dpi),
-  only screen and (                min-resolution: 2dppx) {
+  only screen and (-webkit-min-device-pixel-ratio: 2), 
+  only screen and (min-resolution: 192dpi) {
     background-image: url("@{file-2x}");
     background-size: @width-1x @height-1x;
   }


### PR DESCRIPTION
'min--moz-device-pixel-ratio' is now an unsupported media query from Mozilla. According to Chris Coyer (this)[http://css-tricks.com/snippets/css/retina-display-media-query/] works cross-browser and is much less verbose. 
