### PR TITLE
Expanded Target Area

### DIFF
--- a/less/preboot.less
+++ b/less/preboot.less
@@ -404,3 +404,61 @@
     background-size: @width-1x @height-1x;
   }
 }
+
+// Expanded Target Area
+//
+// For touch devices where you need your element to have
+// an expanded target hit area
+// // For an expanded target hit area
+
+// .expanded-target(10px);
+.expanded-target(@top, @right: null, @bottom: null, @left: null) when (@right = null) {
+  position: relative;
+  &:after {
+    position: absolute;
+    content: ' ';
+    top: -@top;
+    right: -@top;
+    bottom: -@top;
+    left: -@top;
+  }
+}
+
+// .expanded-target(10px, 0);
+.expanded-target(@top, @right: null, @bottom: null, @left: null) when not (@right = null) and (@bottom = null) {
+  position: relative;
+  &:after {
+    position: absolute;
+    content: ' ';
+    top: -@top;
+    right: -@right;
+    bottom: -@top;
+    left: -@right;
+  }
+}
+
+// .expanded-target(10px, 0, 20px);
+.expanded-target(@top, @right: null, @bottom: null, @left: null) when not (@bottom = null) and (@left = null) {
+    position: relative;
+  &:after {
+    position: absolute;
+    content: ' ';
+    top: -@top;
+    right: -@right;
+    bottom: -@bottom;
+    left: -@right;
+  }
+}
+
+// .expanded-target(10px, 0, 20px, 5px);
+.expanded-target(@top, @right: null, @bottom: null, @left: null) when not (@left = null) {
+  position: relative;
+  &:after {
+    position: absolute;
+    content: ' ';
+    top: -@top;
+    right: @right;
+    bottom: -@bottom;
+    left: -@left;
+  }
+}

--- a/less/preboot.less
+++ b/less/preboot.less
@@ -457,7 +457,7 @@
     position: absolute;
     content: ' ';
     top: -@top;
-    right: @right;
+    right: -@right;
     bottom: -@bottom;
     left: -@left;
   }


### PR DESCRIPTION
This is my first pull-request to a public repo, so I'm sorry if I've done this improperly. This mixin allows you to use the :after pseudo-element to make the target hit area of an element bigger, for both hover states and touch tappable areas. See [http://thirdroute.com/blog/css-expanded-hit-areas](http://thirdroute.com/blog/css-expanded-hit-areas).

I'm not sure if this is the best way to go about creating the different scenarios, but I tried to mimic how you  might use CSS shorthand for something like margin: {}  (top, right, bottom, left). 

Note: this mixin automatically converts your `px`, `%` or `em` to negative values.

Uses:

```
.expanded-target(10px); 
.expanded-target(10px, 5px);
.expanded-target(10px, 5px, 7px);
.expanded-target(10px, 5px, 7px, 8px);
```
